### PR TITLE
Fix bug that can't use GitHub envvar assigned in same step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,14 +53,14 @@ jobs:
       # MINECRAFT_VERSION: 1.20.4
       # MOD_GAME_VERSION: 1.5.2+1.20.4
       # MOD_VERSION: 1.5.2
-      # GIT_VERSION_TAG: v1.5.2-1.20.4
+      # GIT_VERSION_TAG: v1.5.2-1.20 (v{mod version}-{branch name})
       - name: Prepare Environment Variables Step 1
         run: |
           echo "MINECRAFT_VERSION=$(grep "minecraft_version" gradle.properties | cut -d'=' -f2)" >> $GITHUB_ENV
           MOD_GAME_VERSION=$(grep "mod_version" gradle.properties | cut -d'=' -f2)
           echo "MOD_GAME_VERSION=${MOD_GAME_VERSION}" >> $GITHUB_ENV
-          echo "MOD_VERSION=$(echo ${{ env.MOD_GAME_VERSION }} | cut -d'+' -f1)" >> $GITHUB_ENV
-          echo "GIT_VERSION_TAG"="v$(echo ${{ env.MOD_GAME_VERSION }} | sed 's/+/-/')" >> $GITHUB_ENV
+          echo "MOD_VERSION=$(echo ${MOD_GAME_VERSION} | cut -d'+' -f1)" >> $GITHUB_ENV
+          echo "GIT_VERSION_TAG"="v${MOD_GAME_VERSION}-${GITHUB_REF##*/}" >> $GITHUB_ENV
 
       # Create temp changelog files, add release note from input and documentation files
       # Extract changelog from CHANGELOG.md, match content between two "*Release*" lines
@@ -78,7 +78,7 @@ jobs:
           awk '/-{3,}/{flag=1;next}/Release/{if (flag==1)exit}flag' \
             ${{ env.CHANGELOG_FILE_PATH }} >> \
             ${{ env.CHANGELOG_TEMP_GITHUB }}
-          sed -i 'i/###/##/g' ${{ env.CHANGELOG_TEMP_GITHUB }}
+          sed -i 's/###/##/' ${{ env.CHANGELOG_TEMP_GITHUB }}
           printf "## Mod Version Compatibility" >> ${{ env.CHANGELOG_TEMP_GITHUB }}
           awk '/Compatibility For ${{ env.MINECRAFT_VERSION }}/{flag=1;next}/----/{next}/Compatibility For/{if (flag==1)exit}flag' \
             ${{ env.MOD_COMPATIBILITY_INFO_FILE_PATH }} \


### PR DESCRIPTION
## Pull Request Checklist

[//]: # (Use `~~ -[ ] ... ~~` markdown deletion syntax to cross out unrelated entries)

- [ ] A new fragment is added in `./doc/news` that describes what is new (refer to issue #174).
- [ ] The unit test suite passes at the latest commit of this PR branch.

## Describe what you have changed in this PR

[//]: # (See commit messages.)