### PR TITLE
Fix wrong git version tag variable in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
       pre-release:
         default: true
         required: false
-        description: Only create a pre-release GitHub release
+        description: Pre Release (only create a pre-release GitHub release, not publish to CurseForge, Modrinth)
         type: boolean
       note:
         default: ''
@@ -53,14 +53,18 @@ jobs:
       # MINECRAFT_VERSION: 1.20.4
       # MOD_GAME_VERSION: 1.5.2+1.20.4
       # MOD_VERSION: 1.5.2
-      # GIT_VERSION_TAG: v1.5.2-1.20 (v{mod version}-{branch name})
-      - name: Prepare Environment Variables Step 1
+      # GIT_VERSION_TAG: v1.5.2-1.20.4 (v{mod version}-{minecraft version})
+      - name: Set Environment Variables
         run: |
           echo "MINECRAFT_VERSION=$(grep "minecraft_version" gradle.properties | cut -d'=' -f2)" >> $GITHUB_ENV
+          
           MOD_GAME_VERSION=$(grep "mod_version" gradle.properties | cut -d'=' -f2)
           echo "MOD_GAME_VERSION=${MOD_GAME_VERSION}" >> $GITHUB_ENV
-          echo "MOD_VERSION=$(echo ${MOD_GAME_VERSION} | cut -d'+' -f1)" >> $GITHUB_ENV
-          echo "GIT_VERSION_TAG"="v${MOD_GAME_VERSION}-${GITHUB_REF##*/}" >> $GITHUB_ENV
+          
+          MOD_VERSION=$(echo ${MOD_GAME_VERSION} | cut -d'+' -f1)
+          echo "MOD_VERSION=${MOD_VERSION}" >> $GITHUB_ENV
+          
+          echo "GIT_VERSION_TAG"="v$(echo ${MOD_GAME_VERSION} | sed 's/+/-/')" >> $GITHUB_ENV
 
       # Create temp changelog files, add release note from input and documentation files
       # Extract changelog from CHANGELOG.md, match content between two "*Release*" lines
@@ -78,7 +82,7 @@ jobs:
           awk '/-{3,}/{flag=1;next}/Release/{if (flag==1)exit}flag' \
             ${{ env.CHANGELOG_FILE_PATH }} >> \
             ${{ env.CHANGELOG_TEMP_GITHUB }}
-          sed -i 's/###/##/' ${{ env.CHANGELOG_TEMP_GITHUB }}
+          sed -i 's/^###/##/' ${{ env.CHANGELOG_TEMP_GITHUB }}
           printf "## Mod Version Compatibility" >> ${{ env.CHANGELOG_TEMP_GITHUB }}
           awk '/Compatibility For ${{ env.MINECRAFT_VERSION }}/{flag=1;next}/----/{next}/Compatibility For/{if (flag==1)exit}flag' \
             ${{ env.MOD_COMPATIBILITY_INFO_FILE_PATH }} \
@@ -89,6 +93,7 @@ jobs:
           awk '/-{3,}/{flag=1;next}/Release/{if (flag==1)exit}flag' \
             ${{ env.CHANGELOG_FILE_PATH }} >> \
             ${{ env.CHANGELOG_TEMP_PLATFORM }}
+          sed -i 's/^###/##/' ${{ env.CHANGELOG_TEMP_PLATFORM }}
 
       - name: Create Github Release
         uses: Kir-Antipov/mc-publish@v3.3


### PR DESCRIPTION
## Pull Request Checklist

[//]: # (Use `~~ -[ ] ... ~~` markdown deletion syntax to cross out unrelated entries)

- [ ] A new fragment is added in `./doc/news` that describes what is new (refer to issue #174).
- [ ] The unit test suite passes at the latest commit of this PR branch.

## Describe what you have changed in this PR

[//]: # (See commit messages.)